### PR TITLE
Copy incubator/raw to ASERVO, remove deprecation, adjust README

### DIFF
--- a/charts/raw/.helmignore
+++ b/charts/raw/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/raw/Chart.yaml
+++ b/charts/raw/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+name: raw
+home: https://github.com/aservo/charts/blob/master/charts/raw
+version: 0.2.5
+appVersion: 0.2.3
+description: A place for all the Kubernetes resources which don't already have a home.

--- a/charts/raw/README.md
+++ b/charts/raw/README.md
@@ -1,0 +1,134 @@
+# Raw Helm Chart
+
+This Helm chart is a copy of the former [incubator/raw](https://github.com/helm/charts/tree/master/incubator/raw) Helm chart that has been marked as deprecated by Helm in November 2020.
+As this chart is not expected to need any maintenance with Helm 3 and as it still provides a high value for us and our customers, we've decided to give it a new home and let it live on without deprecation notice. 😉
+
+## Purpose
+
+The `incubator/raw` chart takes a list of Kubernetes resources and
+merges each resource with a default `metadata.labels` map and installs
+the result.
+
+The Kubernetes resources can be "raw" ones defined under the `resources` key, or "templated" ones defined under the `templates` key.
+
+Some use cases for this chart include Helm-based installation and
+maintenance of resources of kinds:
+- LimitRange
+- PriorityClass
+- Secret
+
+## Usage
+
+### Raw resources
+
+#### STEP 1: Create a yaml file containing your raw resources.
+
+```
+# raw-priority-classes.yaml
+
+resources:
+
+  - apiVersion: scheduling.k8s.io/v1beta1
+    kind: PriorityClass
+    metadata:
+      name: common-critical
+    value: 100000000
+    globalDefault: false
+    description: "This priority class should only be used for critical priority common pods."
+
+  - apiVersion: scheduling.k8s.io/v1beta1
+    kind: PriorityClass
+    metadata:
+      name: common-high
+    value: 90000000
+    globalDefault: false
+    description: "This priority class should only be used for high priority common pods."
+
+  - apiVersion: scheduling.k8s.io/v1beta1
+    kind: PriorityClass
+    metadata:
+      name: common-medium
+    value: 80000000
+    globalDefault: false
+    description: "This priority class should only be used for medium priority common pods."
+
+  - apiVersion: scheduling.k8s.io/v1beta1
+    kind: PriorityClass
+    metadata:
+      name: common-low
+    value: 70000000
+    globalDefault: false
+    description: "This priority class should only be used for low priority common pods."
+
+  - apiVersion: scheduling.k8s.io/v1beta1
+    kind: PriorityClass
+    metadata:
+      name: app-critical
+    value: 100000
+    globalDefault: false
+    description: "This priority class should only be used for critical priority app pods."
+
+  - apiVersion: scheduling.k8s.io/v1beta1
+    kind: PriorityClass
+    metadata:
+      name: app-high
+    value: 90000
+    globalDefault: false
+    description: "This priority class should only be used for high priority app pods."
+
+  - apiVersion: scheduling.k8s.io/v1beta1
+    kind: PriorityClass
+    metadata:
+      name: app-medium
+    value: 80000
+    globalDefault: true
+    description: "This priority class should only be used for medium priority app pods."
+
+  - apiVersion: scheduling.k8s.io/v1beta1
+    kind: PriorityClass
+    metadata:
+      name: app-low
+    value: 70000
+    globalDefault: false
+    description: "This priority class should only be used for low priority app pods."
+```
+
+#### STEP 2: Install your raw resources.
+
+```
+helm install --name raw-priority-classes incubator/raw -f raw-priority-classes.yaml
+```
+
+### Templated resources
+
+#### STEP 1: Create a yaml file containing your templated resources.
+
+```
+# values.yaml
+
+templates:
+- |
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: common-secret
+  stringData:
+    mykey: {{ .Values.mysecret }}
+```
+
+The yaml file containing `mysecret` should be encrypted with a tool like [helm-secrets](https://github.com/futuresimple/helm-secrets)
+
+```
+# secrets.yaml
+mysecret: abc123
+```
+
+```
+$ helm secrets enc secrets.yaml
+```
+
+#### STEP 2: Install your templated resources.
+
+```
+helm secrets install --name mysecret incubator/raw -f values.yaml -f secrets.yaml
+```

--- a/charts/raw/ci/resources-values.yaml
+++ b/charts/raw/ci/resources-values.yaml
@@ -1,0 +1,8 @@
+resources:
+- apiVersion: scheduling.k8s.io/v1
+  kind: PriorityClass
+  metadata:
+    name: common-critical
+  value: 100000000
+  globalDefault: false
+  description: "This priority class should only be used for critical priority common pods."

--- a/charts/raw/ci/templates-values.yaml
+++ b/charts/raw/ci/templates-values.yaml
@@ -1,0 +1,6 @@
+templates:
+- |
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: raw

--- a/charts/raw/ci/values.yaml
+++ b/charts/raw/ci/values.yaml
@@ -1,0 +1,18 @@
+resources:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: common
+  stringData:
+    foo: bar
+
+mysecret: abc134
+
+templates:
+- |
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: common-secret
+  stringData:
+    mykey: "{{ .Values.mysecret }}"

--- a/charts/raw/templates/_helpers.tpl
+++ b/charts/raw/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "raw.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "raw.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "raw.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+raw.resource will create a resource template that can be
+merged with each item in `.Values.resources`.
+*/}}
+{{- define "raw.resource" -}}
+metadata:
+  labels:
+    app: {{ template "raw.name" . }}
+    chart: {{ template "raw.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end }}

--- a/charts/raw/templates/resources.yaml
+++ b/charts/raw/templates/resources.yaml
@@ -1,0 +1,9 @@
+{{- $template := fromYaml (include "raw.resource" .) -}}
+{{- range .Values.resources }}
+---
+{{ toYaml (merge . $template) -}}
+{{- end }}
+{{- range $i, $t := .Values.templates }}
+---
+{{ toYaml (merge (tpl $t $ | fromYaml) $template) -}}
+{{- end }}

--- a/charts/raw/values.yaml
+++ b/charts/raw/values.yaml
@@ -1,0 +1,80 @@
+resources: []
+#
+#  - apiVersion: scheduling.k8s.io/v1beta1
+#    kind: PriorityClass
+#    metadata:
+#      name: common-critical
+#    value: 100000000
+#    globalDefault: false
+#    description: "This priority class should only be used for critical priority common pods."
+#
+#  - apiVersion: scheduling.k8s.io/v1beta1
+#    kind: PriorityClass
+#    metadata:
+#      name: common-high
+#    value: 90000000
+#    globalDefault: false
+#    description: "This priority class should only be used for high priority common pods."
+#
+#  - apiVersion: scheduling.k8s.io/v1beta1
+#    kind: PriorityClass
+#    metadata:
+#      name: common-medium
+#    value: 80000000
+#    globalDefault: false
+#    description: "This priority class should only be used for medium priority common pods."
+#
+#  - apiVersion: scheduling.k8s.io/v1beta1
+#    kind: PriorityClass
+#    metadata:
+#      name: common-low
+#    value: 70000000
+#    globalDefault: false
+#    description: "This priority class should only be used for low priority common pods."
+#
+#  - apiVersion: scheduling.k8s.io/v1beta1
+#    kind: PriorityClass
+#    metadata:
+#      name: app-critical
+#    value: 100000
+#    globalDefault: false
+#    description: "This priority class should only be used for critical priority app pods."
+#
+#  - apiVersion: scheduling.k8s.io/v1beta1
+#    kind: PriorityClass
+#    metadata:
+#      name: app-high
+#    value: 90000
+#    globalDefault: false
+#    description: "This priority class should only be used for high priority app pods."
+#
+#  - apiVersion: scheduling.k8s.io/v1beta1
+#    kind: PriorityClass
+#    metadata:
+#      name: app-medium
+#    value: 80000
+#    globalDefault: true
+#    description: "This priority class should only be used for medium priority app pods."
+#
+#  - apiVersion: scheduling.k8s.io/v1beta1
+#    kind: PriorityClass
+#    metadata:
+#      name: app-low
+#    value: 70000
+#    globalDefault: false
+#    description: "This priority class should only be used for low priority app pods."
+
+templates: []
+# - |
+#  apiVersion: v1
+#  kind: ConfigMap
+#  metadata:
+#    name: raw
+#
+#  - |
+#    apiVersion: v1
+#    kind: Secret
+#    metadata:
+#      name: common-secret
+#    stringData:
+#      mykey: {{ .Values.mysecret }}


### PR DESCRIPTION
I would like to copy over the 'incubator/raw' Helm chart to us in favor of the self-implemented 'util' chart. I've created the util chart back then because of the former intention to create a more complex logic for a variety of resource kinds and ... because I couldn't find the 'incubator/raw' chart anymore, even though I already knew it existed... :laughing: 

I've just removed the deprecation notice from the Chart.yaml, have adjusted the chart's URL in there, fixed Kubernetes deprecations and have adjusted the upper part of the README, e.g. to point to the old chart. The chart's licenses before and after are identical (Apache 2.0). The first version released by ASERVO will be the last version released by Helm (just without the deprecation notice).